### PR TITLE
Make vcpkg toolchain optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 # CMakeLists.txt :contentReference[oaicite:0]{index=0}&#8203;:contentReference[oaicite:1]{index=1}
-set(CMAKE_TOOLCHAIN_FILE
-    "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake"
-    CACHE STRING "")
+if(NOT DEFINED CMAKE_TOOLCHAIN_FILE AND EXISTS "${CMAKE_SOURCE_DIR}/vcpkg")
+    set(CMAKE_TOOLCHAIN_FILE
+        "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+        CACHE STRING "Path to vcpkg toolchain file")
+endif()
 cmake_minimum_required(VERSION 3.10)
 project(Metharizon LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # Metharizon
 A game in the making
+
+## Building
+
+Dependencies are managed with [vcpkg](https://github.com/microsoft/vcpkg).
+If the repository contains a `vcpkg` directory at its root, the CMake
+configuration will automatically use the toolchain file from this directory.
+Otherwise provide the path manually via the `CMAKE_TOOLCHAIN_FILE` cache
+variable, for example:
+
+```sh
+cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake
+```


### PR DESCRIPTION
## Summary
- set `CMAKE_TOOLCHAIN_FILE` only when a `vcpkg` directory is present
- explain how to configure the toolchain in the build instructions

## Testing
- `cmake -S . -B build/tmp -Wno-dev` *(fails: Could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_6862be5bf3e08321a2ba02a7bdca0d0f