### PR TITLE
Add fractal mode switching via number keys

### DIFF
--- a/shaders/raymarch.frag
+++ b/shaders/raymarch.frag
@@ -8,6 +8,7 @@ uniform float u_epsilon;
 uniform mat4  u_objInvTransform;
 uniform vec3  u_camPos, u_camForward, u_camRight, u_camUp;
 uniform uint  u_spawnCount;
+uniform int   u_mode;
 
 // SSBOs
 layout(std430, binding = 0) readonly buffer PosMinors {
@@ -33,10 +34,39 @@ float torusSDF(vec3 p, vec2 t) {
     return length(q) - t.y;
 }
 
+float baseSDF(vec3 op){
+    if(u_mode==1){
+        return length(op) - 1.0; // sphere
+    }else if(u_mode==2){
+        vec3 q = abs(op) - vec3(1.0);
+        return length(max(q,0.0)) + min(max(q.x,max(q.y,q.z)),0.0);
+    }else if(u_mode==3){
+        vec2 q = vec2(length(op.xz) - 0.7, op.y);
+        return length(q) - 0.3; // torus
+    }else if(u_mode==4){
+        vec2 h = vec2(1.0,0.5);
+        vec2 d = abs(vec2(length(op.xz), op.y)) - h;
+        return min(max(d.x,d.y),0.0) + length(max(d,0.0)); // cylinder
+    }else if(u_mode==5){
+        float m = abs(op.x)+abs(op.y)+abs(op.z)-1.0;
+        return m*0.57735027; // octahedron
+    }else if(u_mode==6){
+        vec3 q = abs(op) - vec3(0.5);
+        return length(max(q,0.0)) - 0.1; // rounded box
+    }else if(u_mode==7){
+        vec3 q = abs(op);
+        return max(q.y-0.5,max(q.x*0.866025+q.z*0.5,q.z)-0.5); // hex prism
+    }else if(u_mode==8){
+        vec2 k = vec2(0.5,1.0);
+        float c = length(op.xz)-k.x;
+        return max(c*0.5 + op.y*0.866025 - k.y, -op.y - k.y); // cone
+    }
+    return length(op) - 1.0;
+}
+
 float map(vec3 p) {
-    // Base fractal: rotating unit-sphere
     vec3 op = (u_objInvTransform * vec4(p,1)).xyz;
-    float d = length(op) - 1.0;
+    float d = baseSDF(op);
 
     // Blend in each torus, rotated by its quaternion
     for(uint i=0u; i<u_spawnCount; ++i){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,6 +137,14 @@ int main(){
         if(input.isKeyDown(SDL_SCANCODE_SPACE))  camPos += upVec   * speed * dt;
         if(input.isKeyDown(SDL_SCANCODE_LSHIFT)) camPos -= upVec   * speed * dt;
         if(input.wasKeyPressed(SDL_SCANCODE_ESCAPE)) break;
+        if(input.wasKeyPressed(SDL_SCANCODE_1)) mode = 1;
+        if(input.wasKeyPressed(SDL_SCANCODE_2)) mode = 2;
+        if(input.wasKeyPressed(SDL_SCANCODE_3)) mode = 3;
+        if(input.wasKeyPressed(SDL_SCANCODE_4)) mode = 4;
+        if(input.wasKeyPressed(SDL_SCANCODE_5)) mode = 5;
+        if(input.wasKeyPressed(SDL_SCANCODE_6)) mode = 6;
+        if(input.wasKeyPressed(SDL_SCANCODE_7)) mode = 7;
+        if(input.wasKeyPressed(SDL_SCANCODE_8)) mode = 8;
 
         size_t n = positions.size();
         for(int step=0; step<substeps; ++step){
@@ -264,8 +272,51 @@ int main(){
             }
             // 4) Torus–fractal collisions
             glm::mat4 invX = glm::inverse(fractalXform);
+
+            auto baseSDF = [&](const glm::vec3& p){
+                switch(mode){
+                    case 1: {
+                        return glm::length(p) - 1.0f; // sphere
+                    }
+                    case 2: {
+                        glm::vec3 q = glm::abs(p) - glm::vec3(1.0f);
+                        float m = glm::max(glm::max(q.x, q.y), q.z);
+                        return glm::length(glm::max(q, glm::vec3(0.0f))) +
+                               glm::min(m, 0.0f);
+                    }
+                    case 3: {
+                        glm::vec2 q(glm::length(glm::vec2(p.x, p.z)) - 0.7f, p.y);
+                        return glm::length(q) - 0.3f; // torus
+                    }
+                    case 4: {
+                        glm::vec2 h(1.0f,0.5f);
+                        glm::vec2 d(glm::length(glm::vec2(p.x,p.z)), p.y);
+                        d = glm::abs(d) - h;
+                        return glm::min(glm::max(d.x,d.y),0.0f) + glm::length(glm::max(d, glm::vec2(0.0f)));
+                    }
+                    case 5: {
+                        float m = glm::abs(p.x) + glm::abs(p.y) + glm::abs(p.z) - 1.0f;
+                        return m * 0.57735027f; // octahedron
+                    }
+                    case 6: {
+                        glm::vec3 q = glm::abs(p) - glm::vec3(0.5f);
+                        return glm::length(glm::max(q, glm::vec3(0.0f))) - 0.1f;
+                    }
+                    case 7: {
+                        glm::vec3 q = glm::abs(p);
+                        return glm::max(q.y - 0.5f, glm::max(q.x*0.866025f + q.z*0.5f, q.z) - 0.5f);
+                    }
+                    case 8: {
+                        glm::vec2 k(0.5f,1.0f);
+                        float c = glm::length(glm::vec2(p.x,p.z)) - k.x;
+                        return glm::max(c*0.5f + p.y*0.866025f - k.y, -p.y - k.y);
+                    }
+                }
+                return glm::length(p) - 1.0f;
+            };
+
             auto mapLocal = [&](const glm::vec3& p){
-                float d = glm::length(p) - 1.0f;
+                float d = baseSDF(p);
                 for(size_t k=0;k<n;++k){
                     glm::vec3 sc = glm::vec3(invX * glm::vec4(positions[k],1));
                     glm::vec3 rel = p - sc;


### PR DESCRIPTION
## Summary
- allow selecting different base SDF shapes with keys `1`–`8`
- update shader to handle `u_mode` for various primitives
- compute matching SDF on CPU for collisions

## Testing
- `cmake -S . -B build` *(fails: toolchain file missing)*

------
https://chatgpt.com/codex/tasks/task_e_686389a83c50832184ec0bbdca63f142